### PR TITLE
Remove the PEAR/Pyrus paragraph

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,13 +76,6 @@ php-build [-i &lt;environment_or_inifile&gt;] &lt;definition&gt; &lt;prefix&gt;
 <pre><code>% php-build --definitions
 </code></pre>
 
-<p>By default PHP versions come only with Pyrus (the new Pear installer) preinstalled.
-Pass the <code>--pear</code> flag to enable the legacy Pear installer alongside of Pyrus for enhanced
-compatibility with legacy Pear packages:</p>
-
-<pre><code>% php-build -i development --pear 5.5.9 ~/local/php/5.5.9
-</code></pre>
-
 <h2>
 <a name="meet-the-core-team" class="anchor" href="#meet-the-core-team"><span class="octicon octicon-link"></span></a>Meet the core team</h2>
 


### PR DESCRIPTION
Since [PEAR and Pyrus was removed from php-build](https://github.com/php-build/php-build/pull/347) the project page should be also not mention it anymore.
